### PR TITLE
Fixed source code for windows build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,22 @@ find_package(OpenMP REQUIRED)
 
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}")
 set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}")
-add_compile_options(-std=c++11 -fopenmp -O3 -march=native)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -march=native")
+set(CMAKE_CXX_STANDARD 11)
+if(OPENMP_FOUND)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif()
+if(MSVC)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Ox")
+endif()
 
 include_directories(include)
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Project Webpage: https://graphics.stanford.edu/papers/fastlinkingnumbers/
 
 Supplemental: Derivation of the Two-Tree Barnes–Hut expansion terms used in this implementation [PDF](https://graphics.stanford.edu/papers/fastlinkingnumbers/assets/Qu2021BarnesHutExpandedTermsReference.pdf)
 
+Code: https://github.com/antequ/fastlinkingnumbers
 
 ## Installation
 
-Tested with Ubuntu 18.04, gcc v7.5.0, cmake v3.10.2, gflags v2.2.1, libomp v10.0.0, and Eigen v3.3.4.
+For Ubuntu, we tested with Ubuntu 18.04, gcc v7.5.0, CMake v3.10.2, gflags v2.2.1, libomp v10.0.0, and Eigen v3.3.4. For Windows, we tested with Windows 10, Visual Studio Community 2019 v16.10.2, CMake v3.20.5, and gflags v2.2.2, for 64-bit release.
 
 ### Required packages:
 * [CMake](https://cmake.org/)
@@ -24,9 +25,7 @@ You can install them on Ubuntu 18.04 via
 sudo apt-get install libgflags-dev libeigen3-dev libomp-10-dev build-essential cmake -y
 ```
 
-### Building the executable verifycurves tool
-
-Ubuntu:
+### Building the executable verifycurves tool on Ubuntu
 
 From the root source directory, you can build this like any other CMake project with these commands:
 ```
@@ -40,6 +39,16 @@ ln -s build/obj2bcc obj2bcc
 ```
 
 To build only the `verifycurves` executable, use `make -j verifycurves`. Similarly you can use `make -j obj2bcc` or `make -j libverifycurves` to build the file format converter or the dynamic-link library.
+
+### Running on Windows
+
+Precompiled Binaries:
+
+We've uploaded the compiled 64-bit windows binaries [here](https://drive.google.com/file/d/1nLfxRrf1zoVjY3bT1U-xhz6KByn7yd-S/view?usp=sharing). You may need to install the [Microsoft Visual C++ Redistributable for Visual Studio 2019](https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-redistributable-for-visual-studio-2019) runtime libraries if you do not already have them.
+
+Building from the source code:
+
+To build from the source code, download and install [CMake](https://cmake.org/), [Eigen 3](https://eigen.tuxfamily.org/), [gflags](https://gflags.github.io/gflags/), and Microsoft Visual Studio 2019. Make a `build` subdirectory. In `cmake-gui`, set the project source directory and the build subdirectory. Click "Configure", making sure that it finds Eigen3 and gflags. Then click "Generate", then "Open Project". Build the solution, for Release x64, in Visual Studio.
 
 ### Shared dynamic-link library
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -168,7 +168,7 @@ void Model::ImportFromObjFile(const std::string &filename,
         break;
       line = trimfnc(line);
       std::stringstream::pos_type curr_pos = linestream.tellp();
-      linestream.seekp(curr_pos - 1);
+      linestream.seekp(curr_pos - static_cast<std::streamoff>(1));
       // Note that this will append an extra space since the character before
       // '\\' is often a space.
       linestream << ' ' << line;

--- a/src/potential_link_search.cpp
+++ b/src/potential_link_search.cpp
@@ -6,7 +6,9 @@
 #include "BVH.h"
 #include "curve.h"
 
+#ifndef _MSC_VER 
 #include <parallel/algorithm>
+#endif
 #include <utility>
 #include <vector>
 
@@ -98,8 +100,13 @@ GetPotentialLinksUniqueList(const std::vector<Curve> &curves) {
     BoxBoxIntersectorCurve<int> curve_intersector(ncurves);
     Eigen::BVIntersect(tree, tree, curve_intersector);
     if (curve_intersector.results.size() > parallel_threshold) {
+#ifdef _MSC_VER 
+      std::sort(curve_intersector.results.begin(),
+                curve_intersector.results.end());
+#else
       __gnu_parallel::sort(curve_intersector.results.begin(),
                            curve_intersector.results.end());
+#endif
     } else {
       std::sort(curve_intersector.results.begin(),
                 curve_intersector.results.end());


### PR DESCRIPTION
This change
1) Removes OpenMP 3.1 dependencies for windows MSVC compilation.
2) Removes gnu's parallel sort for windows MSVC compilation.
3) Updates the README with Windows installation instructions.
