### PR TITLE
Add support for LLVM

### DIFF
--- a/src/potential_link_search.cpp
+++ b/src/potential_link_search.cpp
@@ -6,7 +6,7 @@
 #include "BVH.h"
 #include "curve.h"
 
-#ifndef _MSC_VER 
+#if !defined(_MSC_VER) && !defined(__llvm__)
 #include <parallel/algorithm>
 #endif
 #include <utility>
@@ -100,7 +100,7 @@ GetPotentialLinksUniqueList(const std::vector<Curve> &curves) {
     BoxBoxIntersectorCurve<int> curve_intersector(ncurves);
     Eigen::BVIntersect(tree, tree, curve_intersector);
     if (curve_intersector.results.size() > parallel_threshold) {
-#ifdef _MSC_VER 
+#if defined(_MSC_VER) || defined(__llvm__)
       std::sort(curve_intersector.results.begin(),
                 curve_intersector.results.end());
 #else


### PR DESCRIPTION
This PR simply modifies the source to avoid the parallel TS when compiling with LLVM as well as Windows. This seems to be all that was needed to compile and pass the tests with LLVM on Mac.