### PR TITLE
Skip discretization for polylines

### DIFF
--- a/include/curve.h
+++ b/include/curve.h
@@ -41,6 +41,7 @@ typedef Eigen::AlignedBox<double, 3> Box3d;
 class Curve {
 
 public:
+
   /**
    * The default constructor generates an empty, unlooped, B-Spline curve.
    */
@@ -179,12 +180,13 @@ public:
   void set_segment_type(SegmentType type) { segment_type_ = type; }
 
 private:
-  // q_ is the list of control points.
-  std::vector<Point3> q_;
-
   // This value indicates whether the control points are B-Splines, uniform
   // Catmull–Rom splines, Bezier curves, or polylines.
   SegmentType segment_type_ = SegmentType::BSpline;
+  // q_ is the list of control points.
+  std::vector<Point3> q_;
+
+  
 
   // This indicates whether this curve is a closed loop.
   bool looped_ = false;

--- a/include/model.h
+++ b/include/model.h
@@ -23,6 +23,8 @@ namespace VerifyCurves {
  */
 class Model {
 public:
+
+  
   /**
    * The default constructor generates an empty list of curves.
    */
@@ -65,6 +67,14 @@ public:
    */
   void ImportFromObjFile(const std::string &filename, SegmentType segment_type);
 
+  /**
+   * These two methods get and set the segment spline type for the model, assuming they all have the type of the first curve.
+   * For models created from BCC, this is always the case.
+   * whether the control points are B-Splines, uniform Catmull–Rom splines,
+   * Bezier curves, or polylines.
+   */
+  SegmentType get_segment_type() const { return segment_type_; }
+
 private:
   // These methods enable importing from and exporting to BCC files.
   void ImportBccFile(const std::string &filename);
@@ -72,6 +82,7 @@ private:
 
   // Curve data is stored in curves_.
   std::vector<Curve> curves_;
+  SegmentType segment_type_ = SegmentType::BSpline;
 };
 
 } // namespace VerifyCurves

--- a/src/linking_number_certificate.cpp
+++ b/src/linking_number_certificate.cpp
@@ -9,6 +9,7 @@
 #include "compute_link.h"
 #include "discretize.h"
 #include "model.h"
+#include "curve.h" // for SegmentType
 #include "potential_link_search.h"
 
 #include <fstream>
@@ -363,9 +364,17 @@ void LinkingNumberCertificate::ComputeFromModel(const Model &model,
   std::vector<std::vector<int>> potential_links = PotentialLinkSearch(model);
   std::vector<Curve> discretized_curves;
   std::vector<std::vector<int>> potential_links_unique_per_curve;
+
+  if(model.get_segment_type() != SegmentType::Polyline){
   std::cout << "Starting Discretization." << std::endl;
   DiscretizeAndGetNewPotentialLinks(model, potential_links, discretized_curves,
                                     potential_links_unique_per_curve);
+                                    }
+  else{
+    std::cout << "Skipping Discretization for Polylines." << std::endl;
+    discretized_curves = model.GetCurves();
+    potential_links_unique_per_curve = potential_links;
+  }
   if (force_direct_sum) {
     std::cout << "Starting Direct Summation." << std::endl;
     ComputeLinkingNumbersDirectSum(discretized_curves,

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -46,6 +46,7 @@ void Model::ImportFromFile(const std::string &filename) {
   int bcc_ext = strcmp(fileext.c_str(), ".bcc");
   if (bcc_ext == 0) {
     ImportBccFile(filename);
+    segment_type_ = GetCurves()[0].get_segment_type();
   } else {
     std::cerr << "File extension for import must be .bcc: " << filename
               << std::endl;
@@ -145,6 +146,7 @@ void Model::ImportFromObjFile(const std::string &filename,
   int first_vid = -1;
   int last_vid = -1;
   curve.set_segment_type(segment_type);
+  segment_type_ = segment_type;
   while (true) {
     if (!std::getline(file, line))
       break;


### PR DESCRIPTION
This PR modifies the `model` class and the `LinkingNumberCertificate::ComputeFromModel `method to skip discretization for curves defined by polylines.

In our project where we only use polylines, the discretization step was source of errors when polylines would share a point. Since the discretization step only increased the number of vertices for PLs, we bypassed the discretization step for PLs in our application. If this is intended behavior please disregard this PR, otherwise it might be useful for others to have this behavior.

To enforce the check, I added a private `SegmentType` variable in the model class and an additional getter method. 

Many thanks for this awesome code!